### PR TITLE
Refactor unblock actions

### DIFF
--- a/src/borrows/borrow_pcg_action.rs
+++ b/src/borrows/borrow_pcg_action.rs
@@ -1,4 +1,3 @@
-use crate::combined_pcs::UnblockAction;
 use crate::free_pcs::CapabilityKind;
 use crate::rustc_interface::{ast::Mutability, middle::mir::Location};
 use crate::utils::{Place, PlaceRepacker};
@@ -8,6 +7,7 @@ use super::borrows_state::BorrowsState;
 use super::deref_expansion::DerefExpansion;
 use super::path_condition::PathConditions;
 use super::region_projection_member::RegionProjectionMember;
+use super::unblock_graph::BorrowPCGUnblockAction;
 
 /// An action that is applied to a `BorrowsState` during the dataflow analysis
 /// of `BorrowsVisitor`, for which consumers (e.g. Prusti) may wish to perform
@@ -21,7 +21,7 @@ use super::region_projection_member::RegionProjectionMember;
 pub(crate) enum BorrowPcgAction<'tcx> {
     MakePlaceOld(Place<'tcx>),
     SetLatest(Place<'tcx>, Location),
-    Unblock(UnblockAction<'tcx>, Location),
+    Unblock(BorrowPCGUnblockAction<'tcx>, Location),
     AddRegionProjectionMember(RegionProjectionMember<'tcx>, PathConditions),
     InsertDerefExpansion(DerefExpansion<'tcx>, Location),
 }

--- a/src/borrows/borrows_graph.rs
+++ b/src/borrows/borrows_graph.rs
@@ -14,11 +14,22 @@ use crate::{
 };
 
 use super::{
-    borrow_edge::BorrowEdge, borrow_pcg_edge::{
+    borrow_edge::BorrowEdge,
+    borrow_pcg_edge::{
         BlockedNode, BorrowPCGEdge, BorrowPCGEdgeKind, LocalNode, PCGNode, ToBorrowsEdge,
-    }, borrows_visitor::DebugCtx, coupling_graph_constructor::{
+    },
+    borrows_visitor::DebugCtx,
+    coupling_graph_constructor::{
         BorrowCheckerInterface, CGNode, Coupled, CouplingGraphConstructor,
-    }, deref_expansion::DerefExpansion, domain::{AbstractionBlockEdge, LoopAbstraction, MaybeOldPlace, ToJsonWithRepacker}, edge_data::EdgeData, has_pcs_elem::{HasPcsElems, MakePlaceOld}, latest::Latest, path_condition::{PathCondition, PathConditions}, region_abstraction::AbstractionEdge, region_projection_member::RegionProjectionMember
+    },
+    deref_expansion::DerefExpansion,
+    domain::{AbstractionBlockEdge, LoopAbstraction, MaybeOldPlace, ToJsonWithRepacker},
+    edge_data::EdgeData,
+    has_pcs_elem::{HasPcsElems, MakePlaceOld},
+    latest::Latest,
+    path_condition::{PathCondition, PathConditions},
+    region_abstraction::AbstractionEdge,
+    region_projection_member::RegionProjectionMember,
 };
 
 #[derive(Clone, Debug)]

--- a/src/combined_pcs/engine.rs
+++ b/src/combined_pcs/engine.rs
@@ -27,11 +27,7 @@ use rustc_interface::{
 };
 
 use crate::{
-    borrows::{
-        domain::{AbstractionType, MaybeOldPlace, MaybeRemotePlace},
-        engine::BorrowsEngine,
-        region_projection_member::RegionProjectionMember,
-    },
+    borrows::engine::BorrowsEngine,
     free_pcs::{engine::FpcsEngine, CapabilityKind},
     rustc_interface,
     utils::PlaceRepacker,
@@ -194,19 +190,6 @@ impl<'a, 'tcx> AnalysisDomain<'tcx> for PCGEngine<'a, 'tcx> {
         self.curr_block.set(START_BLOCK);
         state.pcg_mut().initialize_as_start_block();
     }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum UnblockAction<'tcx> {
-    TerminateRegionProjectionMember(RegionProjectionMember<'tcx>),
-    TerminateAbstraction(Location, AbstractionType<'tcx>),
-    TerminateBorrow {
-        reserve_location: Location,
-        blocked_place: MaybeRemotePlace<'tcx>,
-        assigned_place: MaybeOldPlace<'tcx>,
-        is_mut: bool,
-    },
-    Collapse(MaybeOldPlace<'tcx>, Vec<MaybeOldPlace<'tcx>>),
 }
 
 impl<'a, 'tcx> Analysis<'tcx> for PCGEngine<'a, 'tcx> {


### PR DESCRIPTION
This PR changes the borrow-PCG unblock annotations to simply contain the corresponding borrow PCG edge, rather than using a custom data structure. This removes a bunch of seemingly unnecessary duplication.

Making a PR for this because it will change the public interface for the PCG.