### PR TITLE
Refactor `BorrowsBridge` to be represented as a list of actions + Other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ To run:
 
 `cargo run [FILENAME].rs`
 
-To view the visualization 
+To view the visualization
 
-1. `PCS_VISUALIZATION=true cargo run [FILENAME.rs]`
+1. `PCG_VISUALIZATION=true cargo run [FILENAME.rs]`
 2. `cd visualization && ./serve`
 3. Go to http://localhost:8080 and select the function you wish to view
 

--- a/src/borrows/borrow_edge.rs
+++ b/src/borrows/borrow_edge.rs
@@ -7,14 +7,14 @@ use super::{
     has_pcs_elem::HasPcsElems,
     region_projection::RegionProjection,
 };
-use crate::rustc_interface::{
+use crate::{rustc_interface::{
     ast::Mutability,
     data_structures::fx::FxHashSet,
     middle::{
         mir::Location,
         ty::{self},
     },
-};
+}, utils::display::DisplayWithRepacker};
 use crate::utils::PlaceRepacker;
 
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
@@ -29,6 +29,17 @@ pub struct BorrowEdge<'tcx> {
     reserve_location: Location,
 
     pub region: ty::Region<'tcx>,
+}
+
+impl<'tcx> DisplayWithRepacker<'tcx> for BorrowEdge<'tcx> {
+    fn to_short_string(&self, repacker: PlaceRepacker<'_, 'tcx>) -> String {
+        format!(
+            "borrow: {} = &{} {}",
+            self.assigned_ref.to_short_string(repacker),
+            if self.mutability == Mutability::Mut { "mut " } else { "" },
+            self.blocked_place.to_short_string(repacker)
+        )
+    }
 }
 
 impl<'tcx, T> HasPcsElems<RegionProjection<'tcx, T>> for BorrowEdge<'tcx> {

--- a/src/borrows/borrow_pcg_action.rs
+++ b/src/borrows/borrow_pcg_action.rs
@@ -16,12 +16,6 @@ use super::region_projection_member::RegionProjectionMember;
 /// An action that is applied to a `BorrowsState` during the dataflow analysis
 /// of `BorrowsVisitor`, for which consumers (e.g. Prusti) may wish to perform
 /// their own effect (e.g. for an unblock, applying a magic wand).
-///
-/// N.B. For now these are only used for debugging. Currently annotations for
-/// consumers are generated via the `bridge` functionality which generates
-/// annotations between two arbitrary `BorrowsState`s. Perhaps we want to remove
-/// that functionality and instead generate annotations for consumers directly
-/// in the `BorrowsVisitor`?
 #[derive(Clone, Debug)]
 pub struct BorrowPCGAction<'tcx> {
     pub(crate) kind: BorrowPCGActionKind<'tcx>,

--- a/src/borrows/borrow_pcg_capabilities.rs
+++ b/src/borrows/borrow_pcg_capabilities.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use crate::free_pcs::CapabilityKind;
+use crate::{
+    free_pcs::CapabilityKind,
+    utils::{display::DisplayWithRepacker, PlaceRepacker},
+};
 
 use super::borrow_pcg_edge::PCGNode;
 
@@ -16,9 +19,11 @@ impl<'tcx> BorrowPCGCapabilities<'tcx> {
         Self(HashMap::new())
     }
 
-    pub(crate) fn debug_capability_lines(&self) -> Vec<String> {
+    pub(crate) fn debug_capability_lines(&self, repacker: PlaceRepacker<'_, 'tcx>) -> Vec<String> {
         self.iter()
-            .map(|(node, capability)| format!("{}: {:?}", node, capability))
+            .map(|(node, capability)| {
+                format!("{}: {:?}", node.to_short_string(repacker), capability)
+            })
             .collect()
     }
 

--- a/src/borrows/borrow_pcg_capabilities.rs
+++ b/src/borrows/borrow_pcg_capabilities.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{free_pcs::CapabilityKind, utils::Place};
+use crate::free_pcs::CapabilityKind;
 
 use super::borrow_pcg_edge::PCGNode;
 
@@ -39,14 +39,6 @@ impl<'tcx> BorrowPCGCapabilities<'tcx> {
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = (PCGNode<'tcx>, CapabilityKind)> + '_ {
         self.0.iter().map(|(k, v)| (k.clone(), v.clone()))
-    }
-
-    pub(crate) fn place_capabilities(
-        &self,
-    ) -> impl Iterator<Item = (Place<'tcx>, CapabilityKind)> + '_ {
-        self.0
-            .iter()
-            .flat_map(|(k, v)| k.as_current_place().map(|p| (p, v.clone())))
     }
 
     pub(crate) fn get<T: Into<PCGNode<'tcx>>>(&self, node: T) -> Option<CapabilityKind> {

--- a/src/borrows/borrow_pcg_edge.rs
+++ b/src/borrows/borrow_pcg_edge.rs
@@ -112,14 +112,7 @@ impl<'tcx> HasPlace<'tcx> for LocalNode<'tcx> {
 }
 
 impl<'tcx> LocalNode<'tcx> {
-    // pub(crate) fn is_current(&self) -> bool {
-    //     match self {
-    //         LocalNode::Place(p) => p.is_current(),
-    //         LocalNode::RegionProjection(rp) => rp.place.is_current(),
-    //     }
-    // }
-
-    pub fn as_cg_node(&self) -> Option<CGNode<'tcx>> {
+    pub(crate) fn as_cg_node(&self) -> Option<CGNode<'tcx>> {
         match self {
             LocalNode::Place(_) => None,
             LocalNode::RegionProjection(rp) => {
@@ -127,7 +120,7 @@ impl<'tcx> LocalNode<'tcx> {
             }
         }
     }
-    pub fn is_old(&self) -> bool {
+    pub(crate) fn is_old(&self) -> bool {
         match self {
             LocalNode::Place(maybe_old_place) => maybe_old_place.is_old(),
             LocalNode::RegionProjection(rp) => rp.place.is_old(),

--- a/src/borrows/borrows_state.rs
+++ b/src/borrows/borrows_state.rs
@@ -91,8 +91,8 @@ impl<'tcx> Default for BorrowsState<'tcx> {
 }
 
 impl<'tcx> BorrowsState<'tcx> {
-    pub(crate) fn debug_capability_lines(&self) -> Vec<String> {
-        self.capabilities.debug_capability_lines()
+    pub(crate) fn debug_capability_lines(&self, repacker: PlaceRepacker<'_, 'tcx>) -> Vec<String> {
+        self.capabilities.debug_capability_lines(repacker)
     }
     pub(crate) fn insert(&mut self, edge: BorrowPCGEdge<'tcx>) -> bool {
         self.graph.insert(edge)

--- a/src/borrows/coupling_graph_constructor.rs
+++ b/src/borrows/coupling_graph_constructor.rs
@@ -9,7 +9,7 @@ use crate::{
         ast::Mutability,
         middle::mir::{BasicBlock, Location},
     },
-    utils::PlaceRepacker,
+    utils::{display::DisplayWithRepacker, PlaceRepacker},
 };
 
 use super::{
@@ -30,6 +30,15 @@ use super::{
 /// Internally, the nodes are stored in a `Vec` to allow for mutation
 #[derive(Clone, Debug, Hash)]
 pub struct Coupled<T>(Vec<T>);
+
+impl<'tcx, T: DisplayWithRepacker<'tcx>> DisplayWithRepacker<'tcx> for Coupled<T> {
+    fn to_short_string(&self, repacker: PlaceRepacker<'_, 'tcx>) -> String {
+        format!(
+            "{{{}}}",
+            self.0.iter().map(|t| t.to_short_string(repacker)).collect::<Vec<_>>().join(", ")
+        )
+    }
+}
 
 impl<T: std::hash::Hash + Eq> PartialEq for Coupled<T> {
     fn eq(&self, other: &Self) -> bool {

--- a/src/borrows/domain.rs
+++ b/src/borrows/domain.rs
@@ -19,7 +19,7 @@ pub struct LoopAbstraction<'tcx> {
 }
 
 impl<'tcx> DisplayWithRepacker<'tcx> for LoopAbstraction<'tcx> {
-    fn to_short_string(&self, repacker: PlaceRepacker<'_, 'tcx>) -> String {
+    fn to_short_string(&self, _repacker: PlaceRepacker<'_, 'tcx>) -> String {
         format!("Loop({:?})", self.block)
     }
 }
@@ -73,7 +73,7 @@ pub struct FunctionCallAbstraction<'tcx> {
 }
 
 impl<'tcx> DisplayWithRepacker<'tcx> for FunctionCallAbstraction<'tcx> {
-    fn to_short_string(&self, repacker: PlaceRepacker<'_, 'tcx>) -> String {
+    fn to_short_string(&self, _repacker: PlaceRepacker<'_, 'tcx>) -> String {
         format!("FunctionCall({:?}, {:?})", self.def_id, self.substs)
     }
 }

--- a/src/borrows/engine.rs
+++ b/src/borrows/engine.rs
@@ -30,7 +30,7 @@ use crate::{
 use super::{
     borrow_pcg_action::BorrowPCGAction,
     borrows_state::BorrowsState,
-    borrows_visitor::{BorrowCheckerImpl, BorrowsVisitor, DebugCtx, StatementStage},
+    borrows_visitor::{BorrowCheckerImpl, BorrowsVisitor, StatementStage},
     coupling_graph_constructor::Coupled,
     domain::{MaybeRemotePlace, RemotePlace, ToJsonWithRepacker},
     path_condition::{PathCondition, PathConditions},
@@ -48,7 +48,7 @@ pub struct BorrowsEngine<'mir, 'tcx> {
 }
 
 impl<'mir, 'tcx> BorrowsEngine<'mir, 'tcx> {
-    pub (crate) fn new(
+    pub(crate) fn new(
         tcx: TyCtxt<'tcx>,
         body: &'mir Body<'tcx>,
         location_table: &'mir LocationTable,
@@ -271,22 +271,6 @@ impl<T> std::ops::IndexMut<EvalStmtPhase> for EvalStmtData<T> {
 
 pub(crate) type BorrowsStates<'tcx> = EvalStmtData<BorrowsState<'tcx>>;
 
-impl<'tcx> BorrowsStates<'tcx> {
-    pub(crate) fn bridge_between_stmts(
-        &self,
-        next: &BorrowsStates<'tcx>,
-        debug_ctx: DebugCtx,
-        repacker: PlaceRepacker<'_, 'tcx>,
-    ) -> (BorrowsBridge<'tcx>, BorrowsBridge<'tcx>) {
-        let start = self
-            .post_main
-            .bridge(&next.pre_operands, debug_ctx, repacker);
-        let middle = next
-            .post_operands
-            .bridge(&next.pre_main, debug_ctx, repacker);
-        (start, middle)
-    }
-}
 #[derive(Clone)]
 /// The domain of the Borrow PCG dataflow analysis. Note that this contains many
 /// fields which serve as context (e.g. reference to a borrow-checker impl to
@@ -322,6 +306,12 @@ impl<'mir, 'tcx> std::fmt::Debug for BorrowsDomain<'mir, 'tcx> {
 }
 
 impl<'mir, 'tcx> BorrowsDomain<'mir, 'tcx> {
+    pub(crate) fn get_bridge(&self) -> (BorrowsBridge<'tcx>, BorrowsBridge<'tcx>) {
+        (
+            self.actions.pre_operands.clone().into(),
+            self.actions.pre_main.clone().into(),
+        )
+    }
     pub(crate) fn post_state(&self) -> &BorrowsState<'tcx> {
         &self.states.post_main
     }

--- a/src/borrows/latest.rs
+++ b/src/borrows/latest.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use serde_json::json;
 
 use crate::rustc_interface::middle::{ty, mir::BasicBlock};
+use crate::utils::display::DisplayWithRepacker;
 use crate::utils::{Place, PlaceRepacker, SnapshotLocation};
 
 use super::domain::ToJsonWithRepacker;

--- a/src/borrows/region_abstraction.rs
+++ b/src/borrows/region_abstraction.rs
@@ -1,6 +1,6 @@
 use rustc_interface::{data_structures::fx::FxHashSet, middle::mir::Location};
 
-use crate::{rustc_interface, utils::PlaceRepacker};
+use crate::{rustc_interface, utils::{display::DisplayWithRepacker, PlaceRepacker}};
 
 use super::{
     borrow_pcg_edge::PCGNode,
@@ -14,6 +14,15 @@ use super::{
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct AbstractionEdge<'tcx> {
     pub abstraction_type: AbstractionType<'tcx>,
+}
+
+impl<'tcx> DisplayWithRepacker<'tcx> for AbstractionEdge<'tcx> {
+    fn to_short_string(&self, repacker: PlaceRepacker<'_, 'tcx>) -> String {
+        match &self.abstraction_type {
+            AbstractionType::FunctionCall(c) => c.to_short_string(repacker),
+            AbstractionType::Loop(c) => c.to_short_string(repacker),
+        }
+    }
 }
 
 impl<'tcx, T> HasPcsElems<T> for AbstractionEdge<'tcx>

--- a/src/borrows/region_projection.rs
+++ b/src/borrows/region_projection.rs
@@ -11,7 +11,7 @@ use crate::{
             ty::{self, DebruijnIndex, RegionVid},
         },
     },
-    utils::{Place, HasPlace},
+    utils::{display::DisplayWithRepacker, HasPlace, Place},
 };
 
 use crate::utils::PlaceRepacker;
@@ -67,6 +67,12 @@ pub struct RegionProjection<'tcx, P = MaybeRemotePlace<'tcx>> {
     pub(crate) place: P,
     region: PCGRegion,
     phantom: PhantomData<&'tcx ()>,
+}
+
+impl<'tcx, T: DisplayWithRepacker<'tcx>> DisplayWithRepacker<'tcx> for RegionProjection<'tcx, T> {
+    fn to_short_string(&self, repacker: PlaceRepacker<'_, 'tcx>) -> String {
+        format!("{}↓{}", self.place.to_short_string(repacker), self.region)
+    }
 }
 
 impl<'tcx, T: ToJsonWithRepacker<'tcx>> ToJsonWithRepacker<'tcx> for RegionProjection<'tcx, T> {

--- a/src/borrows/region_projection_member.rs
+++ b/src/borrows/region_projection_member.rs
@@ -1,6 +1,7 @@
 use serde_json::json;
 
 use crate::rustc_interface::{ast::Mutability, data_structures::fx::FxHashSet};
+use crate::utils::display::DisplayWithRepacker;
 use crate::utils::PlaceRepacker;
 
 use super::borrow_pcg_edge::{LocalNode, PCGNode};
@@ -18,6 +19,16 @@ pub struct RegionProjectionMember<'tcx> {
     pub(crate) inputs: Coupled<PCGNode<'tcx>>,
     pub(crate) outputs: Coupled<LocalNode<'tcx>>,
     pub(crate) kind: RegionProjectionMemberKind,
+}
+
+impl<'tcx> DisplayWithRepacker<'tcx> for RegionProjectionMember<'tcx> {
+    fn to_short_string(&self, repacker: PlaceRepacker<'_, 'tcx>) -> String {
+        format!(
+            "{} -> {}",
+            self.inputs.to_short_string(repacker),
+            self.outputs.to_short_string(repacker)
+        )
+    }
 }
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]

--- a/src/borrows/unblock_graph.rs
+++ b/src/borrows/unblock_graph.rs
@@ -7,6 +7,7 @@ use crate::{
     rustc_interface,
     utils::PlaceRepacker,
     visualization::generate_unblock_dot_graph,
+    ToJsonWithRepacker,
 };
 
 use super::{
@@ -32,6 +33,20 @@ impl<'tcx> BorrowPCGUnblockAction<'tcx> {
     }
 }
 
+impl<'tcx> ToJsonWithRepacker<'tcx> for BorrowPCGUnblockAction<'tcx> {
+    fn to_json(&self, _repacker: PlaceRepacker<'_, 'tcx>) -> serde_json::Value {
+        serde_json::json!({
+            "edge": format!("{:?}", self.edge)
+        })
+    }
+}
+
+impl<'tcx> From<BorrowPCGEdge<'tcx>> for BorrowPCGUnblockAction<'tcx> {
+    fn from(edge: BorrowPCGEdge<'tcx>) -> Self {
+        Self { edge }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum UnblockType {
     ForRead,
@@ -43,6 +58,7 @@ impl<'tcx> UnblockGraph<'tcx> {
         self.edges.iter()
     }
 
+    #[allow(unused)]
     pub(crate) fn to_json(&self, repacker: PlaceRepacker<'_, 'tcx>) -> serde_json::Value {
         let dot_graph = generate_unblock_dot_graph(&repacker, self).unwrap();
         serde_json::json!({

--- a/src/free_pcs/impl/fpcs.rs
+++ b/src/free_pcs/impl/fpcs.rs
@@ -150,10 +150,10 @@ impl<'tcx> Debug for CapabilitySummary<'tcx> {
 }
 
 impl<'tcx> CapabilitySummary<'tcx> {
-    pub(crate) fn debug_lines(&self) -> Vec<String> {
+    pub(crate) fn debug_lines(&self, repacker: PlaceRepacker<'_, 'tcx>) -> Vec<String> {
         self.0
             .iter()
-            .map(|c| c.debug_lines())
+            .map(|c| c.debug_lines(repacker))
             .collect::<Vec<_>>()
             .concat()
     }

--- a/src/free_pcs/impl/local.rs
+++ b/src/free_pcs/impl/local.rs
@@ -15,7 +15,7 @@ use rustc_interface::{
 use crate::{
     free_pcs::{CapabilityKind, RelatedSet, RepackOp},
     rustc_interface,
-    utils::{Place, PlaceOrdering, PlaceRepacker},
+    utils::{display::DisplayWithRepacker, Place, PlaceOrdering, PlaceRepacker},
 };
 
 #[derive(Clone, PartialEq, Eq)]
@@ -42,10 +42,10 @@ impl Default for CapabilityLocal<'_> {
 }
 
 impl<'tcx> CapabilityLocal<'tcx> {
-    pub(crate) fn debug_lines(&self) -> Vec<String> {
+    pub(crate) fn debug_lines(&self, repacker: PlaceRepacker<'_, 'tcx>) -> Vec<String> {
         match self {
             Self::Unallocated => vec![],
-            Self::Allocated(cps) => cps.debug_lines(),
+            Self::Allocated(cps) => cps.debug_lines(repacker),
         }
     }
 
@@ -81,9 +81,9 @@ impl<'tcx> Debug for CapabilityProjections<'tcx> {
 }
 
 impl<'tcx> CapabilityProjections<'tcx> {
-    pub(crate) fn debug_lines(&self) -> Vec<String> {
+    pub(crate) fn debug_lines(&self, repacker: PlaceRepacker<'_, 'tcx>) -> Vec<String> {
         self.iter()
-            .map(|(p, k)| format!("{p:?}: {k:?}"))
+            .map(|(p, k)| format!("{}: {:?}", p.to_short_string(repacker), k))
             .collect()
     }
 

--- a/src/free_pcs/impl/place.rs
+++ b/src/free_pcs/impl/place.rs
@@ -82,12 +82,8 @@ impl PartialOrd for CapabilityKind {
         match (self, other) {
             (CapabilityKind::Write, _) | (_, CapabilityKind::Exclusive) => Some(Ordering::Less),
             (CapabilityKind::Exclusive, _) | (_, CapabilityKind::Write) => Some(Ordering::Greater),
-            (CapabilityKind::Read, _) | (_, CapabilityKind::Lent | CapabilityKind::Exclusive) => {
-                Some(Ordering::Less)
-            }
-            (CapabilityKind::Lent | CapabilityKind::Exclusive, _) | (_, CapabilityKind::Read) => {
-                Some(Ordering::Greater)
-            }
+            (CapabilityKind::Read, _) | (_, CapabilityKind::Lent) => Some(Ordering::Less),
+            (CapabilityKind::Lent, _) | (_, CapabilityKind::Read) => Some(Ordering::Greater),
             _ => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ pub struct BorrowsBridge<'tcx> {
 }
 
 impl<'tcx> BorrowsBridge<'tcx> {
+    /// Actions applied to the PCG, in the order they occurred.
     pub fn actions(&self) -> &[BorrowPCGAction<'tcx>] {
         &self.actions
     }

--- a/src/utils/display.rs
+++ b/src/utils/display.rs
@@ -45,17 +45,23 @@ impl<'tcx> PlaceDisplay<'tcx> {
     }
 }
 
-impl<'tcx> Place<'tcx> {
+pub trait DisplayWithRepacker<'tcx> {
+    fn to_short_string(&self, repacker: PlaceRepacker<'_, 'tcx>) -> String;
+}
 
-    pub fn to_json(&self, repacker: PlaceRepacker<'_, 'tcx>) -> serde_json::Value {
-        serde_json::Value::String(self.to_short_string(repacker))
-    }
-
-    pub fn to_short_string(&self, repacker: PlaceRepacker<'_, 'tcx>) -> String {
+impl<'tcx> DisplayWithRepacker<'tcx> for Place<'tcx> {
+    fn to_short_string(&self, repacker: PlaceRepacker<'_, 'tcx>) -> String {
         match self.to_string(repacker) {
             PlaceDisplay::Temporary(p) => format!("{:?}", p),
             PlaceDisplay::User(_p, s) => s,
         }
+    }
+}
+
+impl<'tcx> Place<'tcx> {
+
+    pub(crate) fn to_json(&self, repacker: PlaceRepacker<'_, 'tcx>) -> serde_json::Value {
+        serde_json::Value::String(self.to_short_string(repacker))
     }
 
     pub fn to_string(&self, repacker: PlaceRepacker<'_, 'tcx>) -> PlaceDisplay<'tcx> {

--- a/src/visualization/mir_graph.rs
+++ b/src/visualization/mir_graph.rs
@@ -1,6 +1,6 @@
 use crate::{
     rustc_interface,
-    utils::{Place, PlaceRepacker},
+    utils::{display::DisplayWithRepacker, Place, PlaceRepacker},
 };
 use serde_derive::Serialize;
 use std::{

--- a/tests/19_lifetime_projection.rs
+++ b/tests/19_lifetime_projection.rs
@@ -7,8 +7,8 @@ struct S<'a> {
 }
 
 fn f<'a>(s: S<'a>) {
-    let x = s.x; // PCG: bb0[1] pre_operands: _1.1: E
-                 // PCG: bb0[1] pre_operands: _1.1↓'?6: E
+    let x = s.x; // PCG: bb0[1] pre_operands: s.y: E
+                 // PCG: bb0[1] pre_operands: s.y↓'?6: E
     let y = s.y.a;
 
 }

--- a/tests/27_aurel.rs
+++ b/tests/27_aurel.rs
@@ -1,0 +1,5 @@
+struct X<'a> { a: &'a mut i32 }
+fn foo_ref_struct<'a>(x: X<'a>) {
+    *x.a = 42;
+}
+fn main(){}

--- a/tests/27_aurel.rs
+++ b/tests/27_aurel.rs
@@ -1,5 +1,5 @@
 struct X<'a> { a: &'a mut i32 }
 fn foo_ref_struct<'a>(x: X<'a>) {
-    *x.a = 42;
+    *x.a = 42; // PCG: bb0[0] pre_main: Weaken *x.a from E to W
 }
 fn main(){}

--- a/tests/run_all_tests.rs
+++ b/tests/run_all_tests.rs
@@ -36,6 +36,7 @@ fn run_all_tests() {
 
         let status = Command::new(&pcs_exe)
             .arg(&test_file)
+            .env("PCG_CHECK_ANNOTATIONS", "true")
             .status()
             .unwrap_or_else(|e| panic!("Failed to execute test {}: {}", test_file.display(), e));
 

--- a/visualization/src/components/BorrowsAndActions.tsx
+++ b/visualization/src/components/BorrowsAndActions.tsx
@@ -5,7 +5,7 @@ import {
   BorrowAction,
   Reborrow,
   MaybeOldPlace,
-  BorrowsBridge as BorrowsBridge,
+  BorrowsBridge,
   PlaceExpand,
   PCGNode,
   MaybeRemotePlace,

--- a/visualization/src/components/BorrowsAndActions.tsx
+++ b/visualization/src/components/BorrowsAndActions.tsx
@@ -5,7 +5,7 @@ import {
   BorrowAction,
   Reborrow,
   MaybeOldPlace,
-  ReborrowBridge as BorrowsBridge,
+  BorrowsBridge as BorrowsBridge,
   PlaceExpand,
   PCGNode,
   MaybeRemotePlace,
@@ -119,83 +119,11 @@ function LocalPCGNodeDisplay({ node }: { node: LocalNode }) {
 
 function BorrowsBridgeDisplay({ bridge }: { bridge: BorrowsBridge }) {
   return (
-    <div>
-      {bridge.added_region_projection_members.length > 0 && (
-        <>
-          Added Region Projection Members: <br />
-          {bridge.added_region_projection_members.map((rp, index) => (
-            <span key={`rp-${index}`}>
-              {"{"}
-              {rp.value.inputs.map((input, i) => (
-                <>
-                  <PCGNodeDisplay node={input} />
-                  {i < rp.value.inputs.length - 1 && ", "}
-                </>
-              ))}
-              {"}"} → {"{"}
-              {rp.value.outputs.map((output, i) => (
-                <>
-                  <LocalPCGNodeDisplay node={output} />
-                  {i < rp.value.outputs.length - 1 && ", "}
-                </>
-              ))}
-              {"}"}
-            </span>
-          ))}
-        </>
-      )}
-      {bridge.weakens.map((weaken, index) => (
-        <span key={`weaken-${index}`}>
-          Weaken <code>{weaken.place}</code>: {weaken.old} → {weaken.new}
-        </span>
+    <ul>
+      {bridge.actions.map((action, index) => (
+        <li key={`action-${index}`}>{action}</li>
       ))}
-      {bridge.expands.length > 0 && (
-        <div>
-          Expands:
-          <BridgeExpands expands={bridge.expands.map((e) => e.value)} />
-        </div>
-      )}
-      {bridge.added_borrows.length > 0 && (
-        <div>
-          Borrows
-          <ul>
-            {bridge.added_borrows.map((reborrow, index) => (
-              <li key={`reborrow-${index}`}>
-                <ReborrowDisplay reborrow={reborrow.value} />
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-      {!bridge.ug.empty && (
-        <a
-          href="#"
-          onClick={(event) => {
-            event.preventDefault();
-            Viz.instance().then((viz) => {
-              const svgElement = viz.renderSVGElement(bridge.ug.dot_graph);
-              const popup = window.open(
-                "",
-                "Dot Graph",
-                "width=800,height=600"
-              );
-              popup.document.body.appendChild(svgElement);
-            });
-          }}
-        >
-          View Dot Graph
-        </a>
-      )}
-    </div>
-  );
-}
-
-function BorrowActionDisplay({ action }: { action: BorrowAction }) {
-  return (
-    <div>
-      <p>Action: {action.action}</p>
-      <BorrowDisplay borrow={action.borrow} />
-    </div>
+    </ul>
   );
 }
 

--- a/visualization/src/types.ts
+++ b/visualization/src/types.ts
@@ -103,15 +103,14 @@ export type RegionProjectionMember = {
   outputs: LocalNode[];
 }
 
-export type ReborrowBridge = {
-  weakens: Weaken[];
-  added_region_projection_members: Conditioned<RegionProjectionMember>[];
-  expands: Conditioned<PlaceExpand>[];
-  added_borrows: Conditioned<Reborrow>[];
-  ug: {
-    dot_graph: string,
-    empty: boolean
-  }
+type BorrowPCGEdge = string;
+
+export type BorrowPCGUnblockAction = {
+  edge: BorrowPCGEdge;
+};
+
+export type BorrowsBridge = {
+  actions: string[];
 };
 
 export type PathData = {
@@ -123,6 +122,6 @@ export type PCGStmtVisualizationData = {
   latest: Record<string, string>;
   free_pcg_repacks_start: string[];
   free_pcg_repacks_middle: string[];
-  borrows_bridge_start: ReborrowBridge;
-  borrows_bridge_middle: ReborrowBridge;
+  borrows_bridge_start: BorrowsBridge;
+  borrows_bridge_middle: BorrowsBridge;
 };


### PR DESCRIPTION
With this new representation, PCG operations in the order which they were originally applied during the processing of a MIR statement.

Also in this PR:
- `BorrowsBridge` no longer exposes an `UnblockGraph` but rather the list of unblock actions directly
- Fixed a bug where in some cases `Weaken` annotations were not being emitted prior to writes
- The construction of the `BorrowsBridge` has changed: previously it was computed by diffing two `BorrowState` objects; now it is constructed by recording the actions that occur during statement processing.
  - As a side note, construction of the `BorrowsBridge` presumably needs to be done some other way for connecting the graph from e.g `bb_x` to `bb_y` where `y` is a join point in the CFG. However, the original implementation didn't handle this case anyways (and just returned an empty bridge) so this change shouldn't break anything.
- Improvements to the testing framework: assertions about borrow actions can now be made in the test files (see `27_aurel.rs`).
- Reduce visibility of some fns from `pub` to `pub(crate)`