### PR TITLE
Fix issue with emitting `W` expand rather than `E`

### DIFF
--- a/src/free_pcs/results/repacks.rs
+++ b/src/free_pcs/results/repacks.rs
@@ -221,6 +221,7 @@ impl<'tcx> RepackOp<'tcx> {
         for_cap: CapabilityKind,
         _ctxt: CompilerCtxt<'_, 'tcx>,
     ) -> Self {
+        assert!(!matches!(for_cap, CapabilityKind::Write));
         Self::Expand(RepackExpand {
             from,
             guide,

--- a/src/pcg/obtain.rs
+++ b/src/pcg/obtain.rs
@@ -55,6 +55,7 @@ impl ObtainType {
         ctxt: CompilerCtxt<'_, 'tcx>,
     ) -> CapabilityKind {
         match self {
+            ObtainType::Capability(CapabilityKind::Write) => CapabilityKind::Exclusive,
             ObtainType::Capability(cap) => *cap,
             ObtainType::TwoPhaseExpand => CapabilityKind::Read,
             ObtainType::LoopInvariant => {


### PR DESCRIPTION
I have no idea if the current diff is a good solution, maybe it breaks many things in other areas. It's mostly for me to test with Prusti. If there's a better fix, feel free to implement it.