### PR TITLE
Better detect if running under cargo

### DIFF
--- a/src/utils/callbacks.rs
+++ b/src/utils/callbacks.rs
@@ -147,7 +147,7 @@ pub fn in_cargo_crate() -> bool {
 /// Is the current compilation running under cargo? Either compiling a crate or
 /// a build script.
 pub fn in_cargo() -> bool {
-    std::env::var("CARGO").ok().is_some()
+    in_cargo_crate() || std::env::var("OUT_DIR").ok().is_some()
 }
 
 #[rustversion::before(2025-03-02)]


### PR DESCRIPTION
`std::env::var("CARGO")` is set even when running with `cargo run` which we don't want, this does not detect that scenario.