### PR TITLE
Provide `context_def_id` from `FunctionData`

### DIFF
--- a/src/borrow_pcg/abstraction/mod.rs
+++ b/src/borrow_pcg/abstraction/mod.rs
@@ -332,6 +332,12 @@ impl<'tcx> FunctionData<'tcx> {
         self.def_id
     }
 
+    pub fn context_def_id(self) -> DefId {
+        self.caller_def_id
+            .map(|local_def_id| local_def_id.to_def_id())
+            .unwrap_or(self.def_id)
+    }
+
     pub(crate) fn shape_data_source(
         self,
         caller_substs: Option<GenericArgsRef<'tcx>>,


### PR DESCRIPTION
Prusti would incorrectly use `FunctionData::substs` as an argument to construct `GParams`. However, the `GParams` only define the *generic parameters* of e.g. a `DefId` (that is the `fn foo<'a, T, U>` thing). The `GArgs` in Prusti are for *generic args* (i.e. substs, such as `foo::<'static, (i32, bool), &'l i32>`).

This PR exposes a way to get the DefId for which we can get the parameters to construct a `GParams`.