### PR TITLE
Fix handling of validity conditions for non-injective edge mutation functions.

### DIFF
--- a/pcg-tests/Cargo.toml
+++ b/pcg-tests/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+# Fixes issues when PCG is included as a submodule
+# See: https://github.com/rust-lang/cargo/issues/5418
+
 [package]
 name = "pcg-tests"
 version = "0.1.0"

--- a/src/borrow_pcg/graph/join.rs
+++ b/src/borrow_pcg/graph/join.rs
@@ -111,15 +111,18 @@ impl<'tcx> BorrowsGraph<'tcx> {
                     rp.try_to_local_node(ctxt.bc_ctxt())
             {
                 let orig_rp = local_rp.with_label(None, ctxt.bc_ctxt());
-                self.filter_mut_edges(|edge| {
-                    edge.value
-                        .label_lifetime_projections(
-                            &LabelNodePredicate::equals_lifetime_projection(orig_rp),
-                            Some(LifetimeProjectionLabel::Future),
-                            ctxt,
-                        )
-                        .to_filter_mut_result()
-                });
+                self.filter_mut_edges(
+                    |edge| {
+                        edge.value
+                            .label_lifetime_projections(
+                                &LabelNodePredicate::equals_lifetime_projection(orig_rp),
+                                Some(LifetimeProjectionLabel::Future),
+                                ctxt,
+                            )
+                            .to_filter_mut_result()
+                    },
+                    ctxt,
+                );
             }
         }
     }
@@ -443,17 +446,20 @@ impl<'tcx> BorrowsGraph<'tcx> {
         );
 
         for rp in &to_label {
-            self.filter_mut_edges(|edge| {
-                edge.value
-                    .label_lifetime_projections(
-                        rp,
-                        Some(LifetimeProjectionLabel::Location(SnapshotLocation::Loop(
-                            loop_head,
-                        ))),
-                        ctxt,
-                    )
-                    .to_filter_mut_result()
-            });
+            self.filter_mut_edges(
+                |edge| {
+                    edge.value
+                        .label_lifetime_projections(
+                            rp,
+                            Some(LifetimeProjectionLabel::Location(SnapshotLocation::Loop(
+                                loop_head,
+                            ))),
+                            ctxt,
+                        )
+                        .to_filter_mut_result()
+                },
+                ctxt,
+            );
         }
 
         for (place, cap_option) in capability_updates {

--- a/src/borrow_pcg/graph/mod.rs
+++ b/src/borrow_pcg/graph/mod.rs
@@ -558,15 +558,19 @@ impl<'tcx, EdgeKind: Eq + std::hash::Hash, VC> BorrowsGraph<'tcx, EdgeKind, VC> 
     ) -> bool
     where
         EdgeKind: LabelEdgeLifetimeProjections<'tcx, Ctxt, P>,
+        VC: ValidityConditionOps<Ctxt>,
     {
         let mut result = false;
-        self.filter_mut_edges(|edge| {
-            let changed: LabelLifetimeProjectionResult = edge
-                .value
-                .label_lifetime_projections(predicate, label, ctxt);
-            result |= changed != LabelLifetimeProjectionResult::Unchanged;
-            changed.to_filter_mut_result()
-        });
+        self.filter_mut_edges(
+            |edge| {
+                let changed: LabelLifetimeProjectionResult = edge
+                    .value
+                    .label_lifetime_projections(predicate, label, ctxt);
+                result |= changed != LabelLifetimeProjectionResult::Unchanged;
+                changed.to_filter_mut_result()
+            },
+            ctxt,
+        );
         result
     }
 }

--- a/src/borrow_pcg/graph/mutate.rs
+++ b/src/borrow_pcg/graph/mutate.rs
@@ -13,6 +13,8 @@ use crate::{
     },
 };
 
+use std::collections::hash_map;
+
 use super::BorrowsGraph;
 
 impl<'tcx> BorrowsGraph<'tcx> {
@@ -34,10 +36,10 @@ fn insert_joining_conditions<EdgeKind: Eq + std::hash::Hash, VC, Ctxt: Copy>(
     VC: ValidityConditionOps<Ctxt>,
 {
     match edges.entry(edge.value) {
-        std::collections::hash_map::Entry::Occupied(mut existing) => {
+        hash_map::Entry::Occupied(mut existing) => {
             existing.get_mut().join(&edge.conditions, ctxt);
         }
-        std::collections::hash_map::Entry::Vacant(slot) => {
+        hash_map::Entry::Vacant(slot) => {
             slot.insert(edge.conditions);
         }
     }

--- a/src/borrow_pcg/graph/mutate.rs
+++ b/src/borrow_pcg/graph/mutate.rs
@@ -4,10 +4,13 @@ use crate::{
         edge_data::{LabelEdgePlaces, NodeReplacement},
         graph::Conditioned,
         has_pcs_elem::PlaceLabeller,
-        validity_conditions::{PathCondition, ValidityConditions},
+        validity_conditions::{PathCondition, ValidityConditionOps, ValidityConditions},
     },
     rustc_interface::middle::mir::BasicBlock,
-    utils::{CompilerCtxt, FilterMutResult, PcgPlace, data_structures::HashSet},
+    utils::{
+        CompilerCtxt, FilterMutResult, PcgPlace,
+        data_structures::{HashMap, HashSet},
+    },
 };
 
 use super::BorrowsGraph;
@@ -16,6 +19,27 @@ impl<'tcx> BorrowsGraph<'tcx> {
     pub(crate) fn filter_for_path(&mut self, path: &[BasicBlock], ctxt: CompilerCtxt<'_, 'tcx>) {
         self.edges
             .retain(|_, conditions| conditions.valid_for_path(path, ctxt.body()));
+    }
+}
+
+/// Insert `edge` into `edges`, joining validity conditions if an identical
+/// edge kind is already present. Edge mutations (e.g. unlabelling lifetime
+/// projections) can make two conditional edges identical; their conditions
+/// must be joined, not overwritten.
+fn insert_joining_conditions<EdgeKind: Eq + std::hash::Hash, VC, Ctxt: Copy>(
+    edges: &mut HashMap<EdgeKind, VC>,
+    edge: Conditioned<EdgeKind, VC>,
+    ctxt: Ctxt,
+) where
+    VC: ValidityConditionOps<Ctxt>,
+{
+    match edges.entry(edge.value) {
+        std::collections::hash_map::Entry::Occupied(mut existing) => {
+            existing.get_mut().join(&edge.conditions, ctxt);
+        }
+        std::collections::hash_map::Entry::Vacant(slot) => {
+            slot.insert(edge.conditions);
+        }
     }
 }
 
@@ -40,51 +64,53 @@ impl<'tcx, EdgeKind> BorrowsGraph<'tcx, EdgeKind> {
 }
 
 impl<'tcx, EdgeKind, VC> BorrowsGraph<'tcx, EdgeKind, VC> {
-    pub(crate) fn mut_edges(
+    pub(crate) fn mut_edges<Ctxt: Copy>(
         &mut self,
         mut f: impl FnMut(&mut Conditioned<EdgeKind, VC>) -> bool,
+        ctxt: Ctxt,
     ) -> bool
     where
         EdgeKind: Eq + std::hash::Hash + PartialEq,
+        VC: ValidityConditionOps<Ctxt>,
     {
         let mut changed = false;
-        self.edges = self
-            .edges
-            .drain()
-            .map(|(kind, conditions)| {
-                let mut edge = Conditioned::new(kind, conditions);
-                if f(&mut edge) {
-                    changed = true;
-                }
-                (edge.value, edge.conditions)
-            })
-            .collect();
+        let mut new_edges = HashMap::default();
+        for (kind, conditions) in self.edges.drain() {
+            let mut edge = Conditioned::new(kind, conditions);
+            if f(&mut edge) {
+                changed = true;
+            }
+            insert_joining_conditions(&mut new_edges, edge, ctxt);
+        }
+        self.edges = new_edges;
         changed
     }
 
-    pub(crate) fn filter_mut_edges(
+    pub(crate) fn filter_mut_edges<Ctxt: Copy>(
         &mut self,
         mut f: impl FnMut(&mut Conditioned<EdgeKind, VC>) -> FilterMutResult,
+        ctxt: Ctxt,
     ) -> bool
     where
         EdgeKind: Eq + std::hash::Hash + PartialEq,
+        VC: ValidityConditionOps<Ctxt>,
     {
         let mut changed = false;
-        self.edges = self
-            .edges
-            .drain()
-            .filter_map(|(kind, conditions)| {
-                let mut edge = Conditioned::new(kind, conditions);
-                match f(&mut edge) {
-                    FilterMutResult::Changed => {
-                        changed = true;
-                        Some((edge.value, edge.conditions))
-                    }
-                    FilterMutResult::Unchanged => Some((edge.value, edge.conditions)),
-                    FilterMutResult::Remove => None,
+        let mut new_edges = HashMap::default();
+        for (kind, conditions) in self.edges.drain() {
+            let mut edge = Conditioned::new(kind, conditions);
+            match f(&mut edge) {
+                FilterMutResult::Changed => {
+                    changed = true;
+                    insert_joining_conditions(&mut new_edges, edge, ctxt);
                 }
-            })
-            .collect();
+                FilterMutResult::Unchanged => {
+                    insert_joining_conditions(&mut new_edges, edge, ctxt);
+                }
+                FilterMutResult::Remove => {}
+            }
+        }
+        self.edges = new_edges;
         changed
     }
     pub(crate) fn label_place<P: PcgPlace<'tcx, Ctxt>, Ctxt: Copy>(
@@ -96,14 +122,18 @@ impl<'tcx, EdgeKind, VC> BorrowsGraph<'tcx, EdgeKind, VC> {
     ) -> HashSet<NodeReplacement<'tcx, P>>
     where
         EdgeKind: LabelEdgePlaces<'tcx, Ctxt, P> + Eq + std::hash::Hash,
+        VC: ValidityConditionOps<Ctxt>,
     {
         let mut all_replacements = HashSet::default();
-        self.mut_edges(|edge| {
-            let replacements = reason.apply_to_edge(place, &mut edge.value, labeller, ctxt);
-            let changed = !replacements.is_empty();
-            all_replacements.extend(replacements);
-            changed
-        });
+        self.mut_edges(
+            |edge| {
+                let replacements = reason.apply_to_edge(place, &mut edge.value, labeller, ctxt);
+                let changed = !replacements.is_empty();
+                all_replacements.extend(replacements);
+                changed
+            },
+            ctxt,
+        );
         all_replacements
     }
 }

--- a/src/borrow_pcg/state/mod.rs
+++ b/src/borrow_pcg/state/mod.rs
@@ -204,6 +204,7 @@ pub(crate) trait BorrowsStateLike<'tcx, EdgeKind = BorrowPcgEdgeKind<'tcx>, VC =
     where
         'tcx: 'a,
         EdgeKind: LabelEdgePlaces<'tcx, Ctxt, P> + Eq + std::hash::Hash,
+        VC: ValidityConditionOps<Ctxt>,
         PcgNodeWithPlace<'tcx, P>: DisplayWithCtxt<Ctxt>,
     {
         let state = self.as_mut_ref();
@@ -230,6 +231,7 @@ pub(crate) trait BorrowsStateLike<'tcx, EdgeKind = BorrowPcgEdgeKind<'tcx>, VC =
     where
         'tcx: 'a,
         EdgeKind: LabelEdgeLifetimeProjections<'tcx, Ctxt, P> + Eq + std::hash::Hash,
+        VC: ValidityConditionOps<Ctxt>,
     {
         self.graph_mut()
             .label_lifetime_projections(predicate, label, ctxt)

--- a/src/owned_pcg/impl/update.rs
+++ b/src/owned_pcg/impl/update.rs
@@ -125,9 +125,6 @@ impl<'tcx> OwnedPcg<'tcx> {
             }
             PlaceCondition::RemoveCapability(place) => {
                 place_capabilities.remove(place, ctxt);
-                if let Some(owned) = place.as_owned_place(ctxt) {
-                    self.remove(owned);
-                }
             }
         }
     }

--- a/src/pcg/owned_state/state.rs
+++ b/src/pcg/owned_state/state.rs
@@ -279,17 +279,6 @@ impl<'tcx> OwnedPcg<'tcx> {
         set_cap_at(tree, root_place, projection, cap, ctxt);
     }
 
-    pub(crate) fn remove(&mut self, place: OwnedPlace<'tcx>) {
-        if place.place().projection.is_empty()
-            && let Some(tree) = self
-                .state
-                .get_mut(place.place().local)
-                .and_then(LocalInitState::tree_mut)
-        {
-            *tree = InitialisationTree::Leaf(OwnedCapability::Uninit);
-        }
-    }
-
     pub(crate) fn remove_strict_postfixes_of(&mut self, place: Place<'tcx>) {
         let Some(tree) = self
             .state

--- a/test-files/228_issue_133_borrow_expiry.rs
+++ b/test-files/228_issue_133_borrow_expiry.rs
@@ -1,0 +1,58 @@
+//! Regression tests for prusti issue-133 (gitlab): capability to a borrowed
+//! local must be fully restored when the borrow expires.
+//!
+//! 1. Lending a place via `&mut` must not mark it uninitialised: on expiry
+//!    the restored capability is computed from the initialisation state, so
+//!    conflating "lent" with "moved out" restores `W` instead of `E`.
+//!
+//! 2. When two conditional variants of an edge become identical (here the
+//!    `x = &mut a` borrow edge, whose labelled lifetime projections differ
+//!    per match arm until they are unlabelled on expiry), their validity
+//!    conditions must be joined. Dropping one variant's conditions makes
+//!    the expiry (and the corresponding permission restoration) conditional
+//!    on a single branch.
+#![feature(box_patterns)]
+
+pub struct U {
+    f: u32,
+}
+
+pub struct ListNode {
+    value: U,
+    next: Option<Box<ListNode>>,
+}
+
+fn use_list_node(_x: &mut ListNode) {}
+fn consume_u(_a: U) {}
+
+pub fn whole_local_borrow_expiry(mut a: ListNode) {
+    let x = &mut a;
+    use_list_node(x);
+    consume_u(a.value);
+    // PCG: bb1[0] pre_operands: Restore capability E to a
+    // PCG: bb1[0] post_operands: a: E
+    // ~PCG: bb1[0] pre_operands: Restore capability W to a
+    // ~PCG: bb1[0] post_operands: a: W
+}
+
+pub fn conditional_reborrow_expiry(mut a: ListNode) {
+    let mut x = &mut a;
+    let x = match x.next {
+        Some(box ref mut node) => node,
+        None => x,
+    };
+    use_list_node(x);
+    consume_u(a.value);
+    // The borrow of `a` was split into two conditional edge variants (one
+    // per match arm); on expiry it must be removed under the union of their
+    // conditions, not just one branch's.
+    // PCG: bb6[0] pre_operands: Remove Edge borrow: x = &mut  a under conditions bb0 -> { bb3, bb2 }
+    // PCG: bb6[0] pre_operands: Restore capability E to a
+    // PCG: bb6[0] post_operands: a: E
+    // ~PCG: bb6[0] pre_operands: Restore capability W to a
+    // ~PCG: bb6[0] post_operands: a: W
+    // ~PCG: bb6[0] pre_operands: Remove Edge borrow: x = &mut  a under conditions bb0 -> bb3
+    // ~PCG: bb6[0] pre_operands: Remove Edge borrow: x = &mut  a under conditions bb0 -> bb2
+}
+
+fn main() {}


### PR DESCRIPTION
Fixed a bug related to mutating PCG edges via mutation functions of the form `f: EdgeData -> EdgeData`. Prevously, if the original borrowsgraph had e1: vc1, e2: vc2, then the resulting graph would have f(e2): vc2 rather than f(e2): join(vc1, vc2) (the original f(e1): vc1 would be overwritten). This fixes the previous behaviour by joining the conditions when an entry is already present.

Also fixed some unrelated code related to tracking initialization state for owned places.